### PR TITLE
fix: snapshot misses position:fixed/sticky elements

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -111,7 +111,10 @@ pub const SNAPSHOT_JS: &str = r#"
     }
 
     function isVisible(el) {
-        if (!el.offsetParent && el.tagName.toLowerCase() !== 'body') return false;
+        if (!el.offsetParent && el.tagName.toLowerCase() !== 'body') {
+            const pos = window.getComputedStyle(el).position;
+            if (pos !== 'fixed' && pos !== 'sticky') return false;
+        }
         const style = window.getComputedStyle(el);
         if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') return false;
         return true;


### PR DESCRIPTION
## Summary

- `offsetParent` returns `null` for `position: fixed` and `position: sticky` elements (per MDN spec), causing `isVisible()` to incorrectly filter them out of snapshots
- Now checks computed `position` before rejecting elements with `null offsetParent`, so modals, dialogs, sticky headers, and dropdowns appear correctly in snapshot output

Fixes #3

## Test plan

- [ ] `cargo check` passes
- [ ] Open a Tauri app with a `position: fixed` modal/dialog
- [ ] Call `snapshot()` while the dialog is open and confirm its content appears in the output