### PR TITLE
fix: add fallback chain for macOS screenshot capture

### DIFF
--- a/packages/tauri-mcp/src/managers/socket.ts
+++ b/packages/tauri-mcp/src/managers/socket.ts
@@ -253,13 +253,16 @@ export class SocketManager {
   }
 
   async screenshot(options?: { window?: string }): Promise<{ data: string; mimeType: string; width: number; height: number }> {
-    // On macOS, use screencapture command which doesn't require Screen Recording permission
-    // when capturing by window ID (the app captures its own window)
+    // On macOS, try screencapture CLI first (no Screen Recording permission needed)
+    // If it fails, fall through to native (xcap → html2canvas)
     if (os.platform() === 'darwin') {
-      return this.screenshotMacOS(options);
+      try {
+        return await this.screenshotMacOS(options);
+      } catch {
+        // screencapture CLI failed, fall through to native
+      }
     }
 
-    // On other platforms, use native screenshot via Rust
     return this.screenshotNative(options);
   }
 


### PR DESCRIPTION
## Summary
- On macOS, `screenshot()` now tries `screencapture` CLI first, and if it fails, falls through to native screenshot (`xcap` → `html2canvas`) instead of returning an error
- This creates a 3-step fallback chain: screencapture CLI → xcap native → html2canvas JS

## Test plan
- [x] Verified fallback triggers when screencapture CLI fails (different error messages confirm both code paths execute)
- [x] Non-macOS platforms unaffected (always go directly to native)