### PR TITLE
feat: add bin field for npx tauri-mcp usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,7 @@ pnpm add github:DaveDev42/tauri-plugin-mcp#main
 
 ### 3. MCP Server
 
-The MCP server is included in the package at:
-```
-node_modules/tauri-plugin-mcp/packages/tauri-mcp/dist/index.js
-```
+The MCP server binary (`tauri-mcp`) is automatically available after installation. No additional setup required.
 
 ## Setup
 
@@ -109,11 +106,32 @@ Add to `.mcp.json` in your project root:
 {
   "mcpServers": {
     "tauri-mcp": {
-      "command": "node",
-      "args": ["node_modules/tauri-plugin-mcp/packages/tauri-mcp/dist/index.js"],
+      "command": "npx",
+      "args": ["tauri-mcp"],
       "env": {
         "TAURI_PROJECT_ROOT": "."
       }
+    }
+  }
+}
+```
+
+> **Note:** pnpm users can also use `pnpx tauri-mcp` or `pnpm exec tauri-mcp`.
+
+### Monorepo Configuration
+
+If the package is installed in a subdirectory (e.g., `apps/desktop`):
+
+```json
+{
+  "mcpServers": {
+    "tauri-mcp": {
+      "command": "npx",
+      "args": ["tauri-mcp"],
+      "env": {
+        "TAURI_PROJECT_ROOT": "./apps/desktop"
+      },
+      "cwd": "./apps/desktop"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "license": "MIT",
   "type": "module",
+  "bin": {
+    "tauri-mcp": "./packages/tauri-mcp/dist/index.js"
+  },
   "exports": {
     ".": {
       "import": "./packages/tauri-plugin-mcp-api/dist/index.js",


### PR DESCRIPTION
## Summary
- Add `bin` field to root `package.json` so consumers can run `npx tauri-mcp` instead of specifying the full path to `node_modules/tauri-plugin-mcp/packages/tauri-mcp/dist/index.js`
- Update README with simplified `.mcp.json` configuration using `npx tauri-mcp`
- Add monorepo configuration guide to README

## Test plan
- [ ] `pnpm build` succeeds
- [ ] `packages/tauri-mcp/dist/index.js` has `#!/usr/bin/env node` shebang
- [ ] After installing the package in a consumer project, `npx tauri-mcp` starts the MCP server