### PR TITLE
docs: add version sync checklist and linux build prereqs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,23 @@ so externals must stay external.
 
 Claude Code only picks up plugin changes when the `version` string is bumped —
 committing to `main` without a bump is invisible to installed users. Version
-lives in **six files** that must stay in lockstep: `Cargo.toml`,
-`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (under
-`plugins[].version`), root `package.json`, and each of the two `packages/*/package.json`.
+lives in **six files** that must stay in lockstep.
+
+### Version Sync Checklist
+
+If you ever bump the version by hand (normally `pnpm release` does it for you),
+every one of these must move together or `pnpm check:versions` / CI will fail:
+
+- [ ] `Cargo.toml` — top-level `version = "x.y.z"`
+- [ ] `.claude-plugin/plugin.json` — `version` field
+- [ ] `.claude-plugin/marketplace.json` — `plugins[0].version`
+- [ ] `package.json` (repo root) — `version` field
+- [ ] `packages/tauri-mcp/package.json` — `version` field
+- [ ] `packages/tauri-plugin-mcp-api/package.json` — `version` field
+
+Run `pnpm check:versions` to verify; it prints `version: x.y.z (in sync)` on
+success or a per-file breakdown on drift. The exact file list lives in
+`scripts/check-versions.mjs`.
 
 Use `pnpm release`:
 
@@ -62,9 +76,33 @@ Two workflows back this up:
   auto-generated notes.
 
 On Linux runners `cargo check` needs GTK/webkit2gtk/pipewire/xdo system
-packages — both workflows install them before `pnpm install`.
+packages — both workflows install them before `pnpm install`. See
+**Linux Build Prerequisites** below for the exact command to mirror locally.
 
 After a successful release, installed users update via `/plugin update tauri-mcp`.
+
+### Linux Build Prerequisites
+
+If `cargo check` / `cargo build` fails locally on Ubuntu/Debian with missing
+`.pc` files or linker errors about `gtk`, `webkit2gtk`, `soup`, etc., you are
+missing the Tauri system deps. CI installs them via `.github/workflows/ci.yml`
+and `release.yml`; run the same command locally:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  libgtk-3-dev \
+  libwebkit2gtk-4.1-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev \
+  libsoup-3.0-dev \
+  libjavascriptcoregtk-4.1-dev \
+  libpipewire-0.3-dev \
+  libxdo-dev
+```
+
+macOS and Windows have no equivalent prereq step — Tauri's system frameworks
+ship with the OS / VS Build Tools.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Two scannable references added to `CLAUDE.md` so contributors don't have to reverse-engineer `scripts/check-versions.mjs` or the CI workflow YAML.

- **Version Sync Checklist** — enumerates the 6 actual version-bearing files (`Cargo.toml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, root `package.json`, `packages/tauri-mcp/package.json`, `packages/tauri-plugin-mcp-api/package.json`) as a bulleted checklist. Previously mentioned inline in prose, now easy to audit at a glance for hand-bumps.
- **Linux Build Prerequisites** — quotes the exact `apt-get install` command from `.github/workflows/ci.yml` and `release.yml` verbatim, so local `cargo check` failures on Ubuntu/Debian have an obvious fix instead of a cryptic pkg-config error.

Docs-only; no code, scripts, or CI logic changed.

## Test plan

- [ ] Review rendered `CLAUDE.md` — checklist and code block render correctly
- [ ] Confirm the 6 file paths in the checklist match the `targets` array in `scripts/check-versions.mjs`
- [ ] Confirm the apt-get package list matches both workflow files byte-for-byte
- [ ] CI (`ci.yml`) passes — no version bump, so `pnpm check:versions` still agrees at `0.3.6`