### PR TITLE
fix(hooks): make SessionStart node_modules link idempotent

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "diff -q \"${CLAUDE_PLUGIN_ROOT}/packages/tauri-mcp/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" >/dev/null 2>&1 || (mkdir -p \"${CLAUDE_PLUGIN_DATA}\" && cp \"${CLAUDE_PLUGIN_ROOT}/packages/tauri-mcp/package.json\" \"${CLAUDE_PLUGIN_DATA}/\" && cd \"${CLAUDE_PLUGIN_DATA}\" && npm install --omit=dev --ignore-scripts --no-audit --no-fund 2>/dev/null) || rm -f \"${CLAUDE_PLUGIN_DATA}/package.json\"; ln -sfn \"${CLAUDE_PLUGIN_DATA}/node_modules\" \"${CLAUDE_PLUGIN_ROOT}/packages/tauri-mcp/node_modules\" 2>/dev/null",
+            "command": "diff -q \"${CLAUDE_PLUGIN_ROOT}/packages/tauri-mcp/package.json\" \"${CLAUDE_PLUGIN_DATA}/package.json\" >/dev/null 2>&1 || (mkdir -p \"${CLAUDE_PLUGIN_DATA}\" && cp \"${CLAUDE_PLUGIN_ROOT}/packages/tauri-mcp/package.json\" \"${CLAUDE_PLUGIN_DATA}/\" && cd \"${CLAUDE_PLUGIN_DATA}\" && npm install --omit=dev --ignore-scripts --no-audit --no-fund 2>/dev/null) || rm -f \"${CLAUDE_PLUGIN_DATA}/package.json\"; if [ ! -L \"${CLAUDE_PLUGIN_ROOT}/packages/tauri-mcp/node_modules\" ]; then rm -rf \"${CLAUDE_PLUGIN_ROOT}/packages/tauri-mcp/node_modules\"; fi; ln -sfn \"${CLAUDE_PLUGIN_DATA}/node_modules\" \"${CLAUDE_PLUGIN_ROOT}/packages/tauri-mcp/node_modules\" 2>/dev/null",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
## Summary
- `ln -sfn` fails when the target already exists as a real directory (it tries to create the symlink **inside**, hitting `node_modules/node_modules: cannot overwrite directory`).
- Subsequent `SessionStart` runs exit non-zero, which the harness reports as a hook failure with no stderr (silenced by `2>/dev/null`).
- Add a `[ ! -L target ] && rm -rf target` guard so the link step is idempotent across missing / real-dir / symlink starting states.

## Reproduction (before fix)
```sh
$ bash -c '<original-command>'
ln: '.../node_modules/node_modules': cannot overwrite directory
$ echo $?
1
```

## After fix
Two consecutive invocations both exit 0; target ends up correctly pointing at `${CLAUDE_PLUGIN_DATA}/node_modules`.

## Test plan
- [x] Manual: run patched command twice against real plugin install — both exit 0
- [x] Verified 3 starting states (missing / real dir / existing symlink) all converge to valid state